### PR TITLE
Fix azienda and ricarica page display

### DIFF
--- a/bulk-transactions-template.csv
+++ b/bulk-transactions-template.csv
@@ -1,0 +1,8 @@
+action,external_batch_id,product_name,quantity,unit,production_date,step_name,step_data,metadata_json,finalize_note
+create_batch,BATCH-2025-0001,Mozzarella di Bufala,120,kg,2025-09-15,,,,{"lot":"L-8421","origin":"Battipaglia"}
+add_step,BATCH-2025-0001,,,,,Confezionamento,"{\"linea\":\"A2\",\"operator\":\"Mario R.\"}","{\"temp\":\"4C\"}",
+add_step,BATCH-2025-0001,,,,,Spedizione,"{\"courier\":\"DHL\",\"tracking\":\"IT123456\"}","{\"dest\":\"Roma\"}",
+finalize_batch,BATCH-2025-0001,,,,,,,,Lotto chiuso e pronto per QR
+create_batch,BATCH-2025-0002,Vino Montepulciano,300,bottle,2025-09-12,,,,{"vintage":2023,"alc_vol":"13%"}
+add_step,BATCH-2025-0002,,,,,Imbottigliamento,"{\"line\":\"B3\"}","{\"cork\":\"natural\"}",
+finalize_batch,BATCH-2025-0002,,,,,,,,Imbottigliamento completato


### PR DESCRIPTION
Fixes blank azienda page after login, updates ricarica page UI for consistency, and ensures latest company data is displayed.

The `azienda` page previously had an early return that prevented rendering if wallet data wasn't instantly available, leading to a blank screen. This PR removes that guard, allowing the UI to handle loading states gracefully. Additionally, company data is now persisted to localStorage from the `azienda` page, enabling the `ricarica` page to preload and display the most current information for name, credits, and status, improving data consistency across pages. The "risparmio" text was removed from the first package on the `ricarica` page as it was irrelevant, and the company name styling was harmonized with the `azienda` page for a consistent user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-7cfc822d-053a-4bf2-b285-398cb2aeb935">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7cfc822d-053a-4bf2-b285-398cb2aeb935">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

