### PR TITLE
Fix company page blank screen error

### DIFF
--- a/src/pages/AziendaPage.tsx
+++ b/src/pages/AziendaPage.tsx
@@ -3698,7 +3698,7 @@ const Dashboard: React.FC<{ companyData: CompanyData }> = ({ companyData }) => {
 
 
 
-      {isLoadingBatches && !showFullPageLoading ? (
+      {(typeof isLoadingBatches !== 'undefined' && isLoadingBatches) && !showFullPageLoading ? (
         null
       ) : errorBatches ? (
 
@@ -7235,7 +7235,7 @@ const AziendaPage: React.FC = () => {
       </div>
 
       {/* Themed loading modal while batches are loading */}
-      {isLoadingBatches && (
+      {(typeof isLoadingBatches !== 'undefined' && isLoadingBatches) && (
         <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-[9999]" role="dialog" aria-modal="true" aria-label="Caricamento iscrizioni">
           <div className="bg-slate-800 rounded-2xl p-8 max-w-md w-full mx-4 text-center shadow-2xl border border-slate-700/50">
             <div className="w-16 h-16 mx-auto mb-6 rounded-full bg-gradient-to-r from-purple-600 to-blue-600 animate-pulse"></div>


### PR DESCRIPTION
Add `typeof` checks for `isLoadingBatches` to prevent `ReferenceError` and the black screen on the azienda page.

The `ReferenceError: isLoadingBatches is not defined` occurred because the variable was sometimes accessed before it was properly defined or initialized, leading to a blank page. Adding these checks ensures the variable exists before being used in conditional renders.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae73f41e-777c-4d68-8d84-b542434cd0e8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ae73f41e-777c-4d68-8d84-b542434cd0e8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

